### PR TITLE
Remove hardcoded namespaces

### DIFF
--- a/charts/ddosify/templates/00_env-configmap.yaml
+++ b/charts/ddosify/templates/00_env-configmap.yaml
@@ -11,7 +11,6 @@ data:
   POSTGRES_PASSWORD: {{ .Values.postgres.password | quote }}
 kind: ConfigMap
 metadata:
-  namespace: ddosify
   labels:
     service: backend-env
   name: env

--- a/charts/ddosify/templates/backend.yaml
+++ b/charts/ddosify/templates/backend.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: backend
   name: backend
@@ -65,7 +64,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: backend
   name: backend

--- a/charts/ddosify/templates/frontend.yaml
+++ b/charts/ddosify/templates/frontend.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: frontend
   name: frontend
@@ -26,7 +25,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: frontend
   name: frontend

--- a/charts/ddosify/templates/hammer.yaml
+++ b/charts/ddosify/templates/hammer.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: hammer
   name: hammer

--- a/charts/ddosify/templates/hammerdebug.yaml
+++ b/charts/ddosify/templates/hammerdebug.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: hammerdebug
   name: hammerdebug

--- a/charts/ddosify/templates/hammermanager.yaml
+++ b/charts/ddosify/templates/hammermanager.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: hammermanager
   name: hammermanager
@@ -52,7 +51,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: hammermanager
   name: hammermanager
@@ -69,7 +67,6 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: hammermanager-celery-beat
   name: hammermanager-celery-beat
@@ -118,7 +115,6 @@ status: {}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: hammermanager-celery-worker
   name: hammermanager-celery-worker

--- a/charts/ddosify/templates/influxdb.yaml
+++ b/charts/ddosify/templates/influxdb.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: ddosify
   name: init-influx-script
 data:
   init.sh: |
@@ -15,7 +14,6 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: influxdb
   name: influxdb
@@ -81,7 +79,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: influxdb
   name: influxdb
@@ -98,7 +95,6 @@ status:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  namespace: ddosify
   labels:
     service: influxdb-data
   name: influxdb-data

--- a/charts/ddosify/templates/ingress.yaml
+++ b/charts/ddosify/templates/ingress.yaml
@@ -4,7 +4,6 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  namespace: ddosify
   name: {{ include "ddosify.fullname" . }}
   annotations:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}

--- a/charts/ddosify/templates/nginx.yaml
+++ b/charts/ddosify/templates/nginx.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   name: nginx-service
 spec:
   type: NodePort
@@ -15,7 +14,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   name: nginx-deployment
 spec:
   replicas: 1
@@ -43,7 +41,6 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: ddosify
   name: nginx-conf
 data:
   default.conf: |

--- a/charts/ddosify/templates/postgres.yaml
+++ b/charts/ddosify/templates/postgres.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: ddosify
   name: init-db-script
 data:
   init.sql: |
@@ -12,7 +11,6 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: postgres
   name: postgres
@@ -57,7 +55,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: postgres
   name: postgres
@@ -74,7 +71,6 @@ status:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  namespace: ddosify
   labels:
     service: postgres-data
   name: postgres-data

--- a/charts/ddosify/templates/rabbitmq.yaml
+++ b/charts/ddosify/templates/rabbitmq.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: rabbitmq-job
   name: rabbitmq-job
@@ -28,7 +27,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: rabbitmq-job
   name: rabbitmq-job
@@ -45,7 +43,6 @@ status:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: rabbitmq-celery
   name: rabbitmq-celery
@@ -70,7 +67,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: rabbitmq-celery
   name: rabbitmq-celery

--- a/charts/ddosify/templates/redis.yaml
+++ b/charts/ddosify/templates/redis.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: redis
   name: redis
@@ -27,7 +26,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: redis
   name: redis

--- a/charts/ddosify/templates/seaweedfs.yaml
+++ b/charts/ddosify/templates/seaweedfs.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: ddosify
   labels:
     service: seaweedfs
   name: seaweedfs
@@ -40,7 +39,6 @@ status: {}
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: ddosify
   labels:
     service: seaweedfs
   name: seaweedfs
@@ -57,7 +55,6 @@ status:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  namespace: ddosify
   labels:
     service: seaweedfs-data
   name: seaweedfs-data


### PR DESCRIPTION
Drop hardcoded namespaces. When you run something like `helm upgrade --install --namespace ddosify ddosify ddosify/ddosify --wait` it sets it for you. Having them hardcoded in the templates isn't overwritten by the helm command, effectively blocking folks from installing anywhere other then namespace `ddosify` 